### PR TITLE
Create µOps.md

### DIFF
--- a/ECE/µOps.md
+++ b/ECE/µOps.md
@@ -1,0 +1,72 @@
+# µOps
+
+### **Micro-Ops (Micro-Operations) in Computer Architecture**
+**Micro-ops (µOps)** are **low-level operations** that a processor executes internally after decoding **complex instructions** (such as x86 instructions). These are used in **modern superscalar and out-of-order CPUs** to **break down complex instructions into simpler steps** that the hardware can handle efficiently.
+
+---
+
+### **How Micro-ops Work**
+1. **Instruction Fetch** → CPU retrieves a complex instruction (e.g., `ADD R1, R2, R3`).
+2. **Instruction Decode** → CPU **converts** this high-level instruction into **one or more micro-ops**.
+3. **Micro-op Execution** → Each micro-op is executed in the **execution pipeline**.
+4. **Result Writeback** → The final result is stored in the destination register.
+
+---
+
+### **Examples of Micro-ops**
+#### **Example 1: ADD Instruction in x86**
+```assembly
+ADD EAX, EBX  ; High-level x86 instruction
+```
+- **This could break down into these micro-ops:**
+  1. **Fetch EBX**
+  2. **Fetch EAX**
+  3. **Perform ALU addition**
+  4. **Write result to EAX**
+
+#### **Example 2: Memory Load (MOV Instruction)**
+```assembly
+MOV ECX, [MEM]  ; Load a value from memory into ECX
+```
+- **Micro-ops breakdown:**
+  1. **Calculate memory address**
+  2. **Read from memory**
+  3. **Store value in ECX**
+
+---
+
+### **Why Micro-ops Are Important**
+✅ **Optimizes CPU execution** – Complex instructions are broken into smaller parts for **parallel execution**.  
+✅ **Improves out-of-order execution** – Instructions can be **reordered** internally for better performance.  
+✅ **Allows instruction fusion** – Some micro-ops can be **combined** for efficiency (e.g., "macro-fusion" in Intel CPUs).  
+✅ **Reduces pipeline stalls** – Helps avoid **bottlenecks** in modern CPU pipelines.
+
+---
+
+### **Micro-ops in Modern CPUs**
+- **Intel's Micro-Op Cache** – Stores decoded µOps to **avoid re-decoding** frequently used instructions.
+- **AMD's μOp Execution** – Uses an "op-cache" to **reduce decoding overhead**.
+- **RISC vs. CISC Architectures** – RISC CPUs inherently use simpler instructions, reducing the need for micro-ops.
+
+---
+
+### **Fun Prolog Representation of Micro-ops**
+```prolog
+% Micro-op definitions
+micro_op(add, [fetch_reg, fetch_reg, alu_add, write_back]).
+micro_op(mov_mem, [calc_address, read_memory, write_reg]).
+
+% Execute a high-level instruction by breaking it into micro-ops
+execute_instruction(Instruction, MicroOps) :-
+    micro_op(Instruction, MicroOps).
+```
+#### **Querying in Prolog:**
+```prolog
+?- execute_instruction(add, X).
+X = [fetch_reg, fetch_reg, alu_add, write_back].
+```
+---
+### **Summary**
+🚀 **Micro-ops** are the **hidden low-level operations** inside modern CPUs that allow **efficient instruction execution** by breaking down complex instructions into **simpler steps**.  
+
+Would you like to see **more examples**, **Prolog-based simulation**, or **specific CPU architectures**? 😆🔥


### PR DESCRIPTION
```markdown
# µOps

### **Micro-Ops (Micro-Operations) in Computer Architecture**
**Micro-ops (µOps)** are **low-level operations** that a processor executes internally after decoding **complex instructions** (such as x86 instructions). These are used in **modern superscalar and out-of-order CPUs** to **break down complex instructions into simpler steps** that the hardware can handle efficiently.

---

### **How Micro-ops Work**
1. **Instruction Fetch** → CPU retrieves a complex instruction (e.g., `ADD R1, R2, R3`).
2. **Instruction Decode** → CPU **converts** this high-level instruction into **one or more micro-ops**.
3. **Micro-op Execution** → Each micro-op is executed in the **execution pipeline**.
4. **Result Writeback** → The final result is stored in the destination register.

---

### **Examples of Micro-ops**
#### **Example 1: ADD Instruction in x86**
```assembly
ADD EAX, EBX  ; High-level x86 instruction
```
- **This could break down into these micro-ops:**
  1. **Fetch EBX**
  2. **Fetch EAX**
  3. **Perform ALU addition**
  4. **Write result to EAX**

#### **Example 2: Memory Load (MOV Instruction)**
```assembly
MOV ECX, [MEM]  ; Load a value from memory into ECX
```
- **Micro-ops breakdown:**
  1. **Calculate memory address**
  2. **Read from memory**
  3. **Store value in ECX**

---

### **Why Micro-ops Are Important**
✅ **Optimizes CPU execution** – Complex instructions are broken into smaller parts for **parallel execution**.  
✅ **Improves out-of-order execution** – Instructions can be **reordered** internally for better performance.  
✅ **Allows instruction fusion** – Some micro-ops can be **combined** for efficiency (e.g., "macro-fusion" in Intel CPUs).  
✅ **Reduces pipeline stalls** – Helps avoid **bottlenecks** in modern CPU pipelines.

---

### **Micro-ops in Modern CPUs**
- **Intel's Micro-Op Cache** – Stores decoded µOps to **avoid re-decoding** frequently used instructions.
- **AMD's μOp Execution** – Uses an "op-cache" to **reduce decoding overhead**.
- **RISC vs. CISC Architectures** – RISC CPUs inherently use simpler instructions, reducing the need for micro-ops.

---

### **Fun Prolog Representation of Micro-ops**
```prolog
% Micro-op definitions
micro_op(add, [fetch_reg, fetch_reg, alu_add, write_back]). micro_op(mov_mem, [calc_address, read_memory, write_reg]).

% Execute a high-level instruction by breaking it into micro-ops execute_instruction(Instruction, MicroOps) :-
    micro_op(Instruction, MicroOps).
```
#### **Querying in Prolog:**
```prolog
?- execute_instruction(add, X).
X = [fetch_reg, fetch_reg, alu_add, write_back].
```
---
### **Summary**
🚀 **Micro-ops** are the **hidden low-level operations** inside modern CPUs that allow **efficient instruction execution** by breaking down complex instructions into **simpler steps**.  

Would you like to see **more examples**, **Prolog-based simulation**, or **specific CPU architectures**? 😆🔥
```